### PR TITLE
Update to the documentation - stating that we are now only supporting…

### DIFF
--- a/NearBeach/requirements.txt
+++ b/NearBeach/requirements.txt
@@ -1,5 +1,5 @@
 # requirement.txt
-Django
+Django>=3.1
 simplejson
 pillow>=7.1.0
 urllib3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ Software
 
 * Ubuntu 18.04
 * Python 3.6+
-* Django 2.1+
+* Django 3.1+
 * Nginx
 * Gunicorn
 * MySQL

--- a/docs/setup-dev-environment/setup_development_environment.rst
+++ b/docs/setup-dev-environment/setup_development_environment.rst
@@ -12,8 +12,7 @@ Security fixes/patches are applied for a longer period of time, helping keep you
 
 NearBeach currently supports the following Django versions;
 
-- Django Version 2.2 LTS
-- Django Version 3.0
+- Django Version 3.1
 
 More information about upgrading Django can be found `found in the Django Documentation <https://docs.djangoproject.com/en/3.0/howto/upgrade-version/>`_
 

--- a/docs/update/update_or_patch_nearbeach.rst
+++ b/docs/update/update_or_patch_nearbeach.rst
@@ -16,8 +16,7 @@ Security fixes/patches are applied for a longer period of time, helping keep you
 
 NearBeach currently supports the following Django versions;
 
-- Django Version 2.2 LTS
-- Django Version 3.0
+- Django Version 3.1+
 
 More information about upgrading Django can be found `found in the Django Documentation <https://docs.djangoproject.com/en/3.0/howto/upgrade-version/>`_
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # requirement.txt
-Django
+Django>=3.1
 simplejson
 pillow>=7.1.0
 urllib3


### PR DESCRIPTION
# Description

Update to the documentation - implying we are only supporting Django 3.1+ versions, this is due to a feature they have implemented. ISO 8061