### PR TITLE
Use the  statement to open a file PTC-W0010

### DIFF
--- a/NearBeach/private_media.py
+++ b/NearBeach/private_media.py
@@ -183,11 +183,14 @@ class DefaultServer(object):
         if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'),
                                   statobj[stat.ST_MTIME], statobj[stat.ST_SIZE]):
             return HttpResponseNotModified(content_type=content_type)
-        response = HttpResponse(open(fullpath, 'rb').read(), content_type=content_type)
-        response["Last-Modified"] = http_date(statobj[stat.ST_MTIME])
+
+        with open(fullpath, 'rb') as f:
+            response = HttpResponse(f.read(), content_type=content_type)
+            response["Last-Modified"] = http_date(statobj[stat.ST_MTIME])
+            return response
+
         # filename = os.path.basename(path)
         # response['Content-Disposition'] = smart_str(u'attachment; filename={0}'.format(filename))
-        return response
 
 
 """


### PR DESCRIPTION
# Description

Fixed deepsource identified antipattern: "File opened without the `with` statement PTC-W0010"
This change involves using with rather than open for file handling.

More details can be found here: https://deepsource.io/gh/robotichead/NearBeach/issue/PTC-W0010/occurrences

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Database change that requires a migration
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x ] python ./manage.py test
- [x] Local testing via "./manage runserver"
- [x] Tested on virtual box
- [x] Tested on server

# Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] Any dependent changes have been merged and published in downstream modules
