### PR TITLE
Fixed CODE OF CONDUCT LINK in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ If you would like to join our community, please join our [fun and exciting disco
 
 ## Code of Conduct
 
-Please read our [code of conduct here].
+Please read our [code of conduct here](https://github.com/robotichead/NearBeach/blob/main/CODE_OF_CONDUCT.md).
 
 
 ## NearBeach Overview


### PR DESCRIPTION
# Fixed CODE OF CONDUCT LINK in CONTRIBUTING.md

In CONTRIBUTING.md  LINE-23 "Please read our code of conduct here", when clicked on "code of conduct here" it was suppose to launch on CODE_OF_CONDUCT.md but it was not happening because there was no link present to direct on the code of conduct page. 

-This change is tested on my system.





