### PR TITLE
fix-deprecated lifecycle hooks

### DIFF
--- a/src/js/components/kanban/KanbanBoard.vue
+++ b/src/js/components/kanban/KanbanBoard.vue
@@ -102,7 +102,7 @@ export default {
 		window.addEventListener("resize", this.resizeProcedure);
 		window.addEventListener("scroll", this.scrollProcedure);
 	},
-	destroyed() {
+	unmounted() {
 		window.removeEventListener("resize", this.resizeProcedure);
 		window.removeEventListener("scroll", this.scrollProcedure);
 	},


### PR DESCRIPTION
# Description

Changed the  deprecated lifecycle hooks. The "destroyed" lifecycle hook is deprecated, so changed to "unmounted".

bug fixes ##482 by @AmithBino

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Database change that requires a migration
-   [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-   [ ] Local manual testing via "./manage runserver"
-   [ ] Local Python Unit Testing via "./manage test"
-   [ ] Local Cypress E2E Testing
-   [ ] Tested on virtual box
-   [ ] Tested on server

# Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
