### PR TITLE
Updated document_views.py

### DIFF
--- a/NearBeach/views/document_views.py
+++ b/NearBeach/views/document_views.py
@@ -567,4 +567,5 @@ def get_file_handler(settings):
         return AzureFileHanlder(settings)
     return LocalFileHandler(settings)
 
+
 FILE_HANDLER = get_file_handler(settings)


### PR DESCRIPTION
Added the required 2 blank lines after end of function or class

# Description

This PR fixes the issue of one occurrence of required 2 blank lines after end of function or class.

## Fixes #484

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Database change that requires a migration
-   [ ] This change requires a documentation update

# How Has This Been Tested?


-   [ ] Local manual testing via "./manage runserver"
-   [ ] Local Python Unit Testing via "./manage test"
-   [ ] Local Cypress E2E Testing
-   [ ] Tested on virtual box
-   [ ] Tested on server

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
