### PR TITLE
fix:Used template literals instead of string concatenation

### DIFF
--- a/src/js/components/tags/EditTagModal.vue
+++ b/src/js/components/tags/EditTagModal.vue
@@ -189,7 +189,7 @@ export default {
 			let return_class = "single-colour";
 
 			if (colour == this.tagColourModel) {
-				return_class = return_class + " selected-colour";
+				return_class = `${return_class} selected-colour`;
 			}
 
 			return return_class;


### PR DESCRIPTION
# Description

This PR changed the line of code which uses string concatenation by using template literals instead

## Fixes #486 

## Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Database change that requires a migration
-   [ ] This change requires a documentation update

# How Has This Been Tested?
-   [ ] Local manual testing via "./manage runserver"
-   [ ] Local Python Unit Testing via "./manage test"
-   [ ] Local Cypress E2E Testing
-   [ ] Tested on virtual box
-   [ ] Tested on server

# Checklist:

-   [X ] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [X ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
