### PR TITLE
fix: added two spaces for inline comment

### DIFF
--- a/NearBeach/views/change_task_views.py
+++ b/NearBeach/views/change_task_views.py
@@ -237,7 +237,7 @@ def update_status(request, change_task_id, *args, **kwargs):
     if not rfc_results.rfc_status_id == 4:
         return HttpResponse(
             "RFC Currently Locked - not in start mode",
-            status = 423 # Locked
+            status = 423  # Locked
         )
 
     # Update the change task results


### PR DESCRIPTION
# Description

This PR added two spaces for the inline comment instead of 1 space

## Fixes #485 

## Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Database change that requires a migration
-   [ ] This change requires a documentation update

# How Has This Been Tested?
-   [ ] Local manual testing via "./manage runserver"
-   [ ] Local Python Unit Testing via "./manage test"
-   [ ] Local Cypress E2E Testing
-   [ ] Tested on virtual box
-   [ ] Tested on server

# Checklist:

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [X] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
