### PR TITLE
fix:Fixed multiple space after keyword

### DIFF
--- a/NearBeach/views/document_views.py
+++ b/NearBeach/views/document_views.py
@@ -481,7 +481,7 @@ class LocalFileHandler(FileHandler):
 
 
 class S3FileHandler(FileHandler):
-    def  __init__(self, settings):
+    def __init__(self, settings):
         botoInitValues = {
             "aws_access_key_id": settings.AWS_ACCESS_KEY_ID,
             "aws_secret_access_key": settings.AWS_SECRET_ACCESS_KEY,


### PR DESCRIPTION
# Description

This PR fixes the multiple space after keyword by removing extra space
#Fixes #487 

## Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Database change that requires a migration
-   [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-   [ ] Local manual testing via "./manage runserver"
-   [ ] Local Python Unit Testing via "./manage test"
-   [ ] Local Cypress E2E Testing
-   [ ] Tested on virtual box
-   [ ] Tested on server

# Checklist:

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [X] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
